### PR TITLE
be more tolerant of POD errors

### DIFF
--- a/lib/Pod/Weaver/Plugin/EnsureUniqueSections.pm
+++ b/lib/Pod/Weaver/Plugin/EnsureUniqueSections.pm
@@ -89,7 +89,7 @@ nothing. It does not modify the POD in any way.
 sub finalize_document {
     my ($self, $document) = @_;
     my $headers = $document->children
-        ->grep(sub{ $_->command eq 'head1' })
+        ->grep(sub{ $_->can( 'command' ) and $_->command eq 'head1' })
             ->map(sub{ $_->content });
     my %header_group;
     for my $h (@$headers) {


### PR DESCRIPTION
Hello,

 I was building a new dist and noticed this error stopping the build:

Can't locate object method "command" via package "Pod::Elemental::Element::Pod5::Ordinary" at /usr/local/share/perl/5.10.0/Pod/Weaver/Plugin/EnsureUniqueSections.pm line 48, <FILE> line 145.

 It was hard to track down the actual error because this was throwing my debugging session off. The actual error is... I had malformed POD in my code ( I mistakenly thought I could do =sub foobar instead of =func foobar for the Pod::Weaver::Section::Collect stuff ) and caught it _after_ I made this change.

 It technically is not necessary, but I feel it's helpful as it makes the module more robust against this kind of error in the future and will allow other hapless developers to quickly track down their incorrect POD :)

Thanks again!
