### PR TITLE
Log content of the duplication sections to aid debugging

### DIFF
--- a/lib/Pod/Weaver/Plugin/EnsureUniqueSections.pm
+++ b/lib/Pod/Weaver/Plugin/EnsureUniqueSections.pm
@@ -124,6 +124,17 @@ sub finalize_document {
         ->map(sub{ @{$header_group{$_}} > 1 ? $header_group{$_}->head : () })
             ->sort;
     if (@$duplicate_headers > 0) {
+        my $pod_string = "";
+        for my $h (@$duplicate_headers) {
+            for my $node (@{ $document->children->grep(
+                sub {
+                    $_->can('command') && $_->command eq 'head1' &&
+                        $_->content eq $h
+                    }) }) {
+                $pod_string .= $node->as_pod_string;
+            }
+        }
+        $self->log_debug(["POD of duplicated headers:\n\n%s", $pod_string]);
         my $message = "Error: The following headers appear multiple times: '" . $duplicate_headers->join(q{', '}) . q{'};
         $self->log_fatal($message);
     }


### PR DESCRIPTION
Instead of just this:

```
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] Error: The following headers appear multiple times: 'DESCRIPTION'
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] Error: The following headers appear multiple times: 'DESCRIPTION' at /home/s1/perl5/perlbrew/perls/perl-5.24.0/lib/site_perl/5.24.0/x86_64-linux/Moose/Meta/Method/Delegation.pm line 110.
```

dzil now outputs this which I find more helpful when debugging the source of duplication:

```
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] 
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] =head1 DESCRIPTION
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] 
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] Packaging a benchmark script as a Bencher scenario makes it convenient to include/exclude/add participants/datasets (either via CLI or Perl code), send the result to a central repository, among others . See L<Bencher> and L<bencher> (CLI) for more details.
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] 
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] =head1 DESCRIPTION
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] 
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] TODO: include more set modules.
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] 
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] TODO: compare complex elements.
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] 

[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] Error: The following headers appear multiple times: 'DESCRIPTION'
[@Author::PERLANCAR/PodWeaver] [@Author::PERLANCAR/EnsureUniqueSections] Error: The following headers appear multiple times: 'DESCRIPTION' at /home/s1/perl5/perlbrew/perls/perl-5.24.0/lib/site_perl/5.24.0/x86_64-linux/Moose/Meta/Method/Delegation.pm line 110.
```
